### PR TITLE
Run PSScriptAnalyzer only on pull request

### DIFF
--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -10,8 +10,6 @@
 name: PSScriptAnalyzer
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
     


### PR DESCRIPTION
Disable PSScriptAnalyzer action on push because the main branch does not accept pushes.