### PR TITLE
Fix dotnet-format folder does not exist error

### DIFF
--- a/hooks/dotnet_format.py
+++ b/hooks/dotnet_format.py
@@ -37,20 +37,25 @@ def dotnet_format() -> bool:
     solution = get_solution()
     files = [str(f) for f in util.get_input_files()]
 
-    try:
-        command = [
-            # fmt: off
-            "dotnet", "format", solution,
-            "--verify-no-changes",
-            "--severity", "warn",
-            "--include", *files,
-            # fmt: on
-        ]
-        print(command)
-        subprocess.check_output(command, text=True)
+    command = [
+        # fmt: off
+        "dotnet", "format", solution,
+        "--verify-no-changes",
+        "--severity", "warn",
+        "--include", *files,
+        # fmt: on
+    ]
 
-    except subprocess.CalledProcessError:
-        rv = False
+    if solution:
+        try:
+            subprocess.check_output(command, text=True)
+
+        except subprocess.CalledProcessError:
+            log.error(f"Command failed: {command}")
+            rv = False
+
+    else:
+        log.warning("No solutions found")
 
     return rv
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pre-commit-hooks"
-version = "0.0.9"
+version = "0.0.10"
 description = "A small collection of pre-commit hooks."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Raise warning when no solutions are found instead of running the dotnet format command. Fixes #25 